### PR TITLE
Replace removed Maverick prompt model

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint",
+    "verify:models": "node scripts/verify-models.mjs",
     "update:all": "pnpm update --interactive --latest"
   },
   "dependencies": {

--- a/scripts/verify-models.mjs
+++ b/scripts/verify-models.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const imageRoute = await readFile(
+  new URL("../src/app/api/image/route.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(imageRoute, /Qwen\/Qwen3\.5-9B/);
+assert.doesNotMatch(
+  imageRoute,
+  /meta-llama\/Llama-4-Maverick-17B-128E-Instruct-FP8/,
+  "The image prompt route must not use the removed Llama Maverick endpoint",
+);
+
+console.log("SmartPDFs model configuration excludes removed endpoints.");

--- a/src/app/api/image/route.ts
+++ b/src/app/api/image/route.ts
@@ -5,6 +5,8 @@ import { awsS3Client } from "@/lib/s3client";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { generateText } from "ai";
 
+const IMAGE_PROMPT_MODEL = "Qwen/Qwen3.5-9B";
+
 export async function POST(req: Request) {
   const json = await req.json();
   const text = "text" in json ? json.text : "";
@@ -14,9 +16,7 @@ export async function POST(req: Request) {
   const truncatedText = text.slice(0, 2000);
 
   const { text: visualDescription } = await generateText({
-    model: togetheraiClient(
-      "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    ),
+    model: togetheraiClient(IMAGE_PROMPT_MODEL),
     prompt: dedent`
       Based on the following content, describe a single visual scene that represents its essence. 
       The scene should be suitable for a painting or illustration.


### PR DESCRIPTION
## Summary

- replace the removed Llama 4 Maverick scene-description model with Qwen/Qwen3.5-9B
- keep FLUX.2 dev image generation unchanged
- add a model lifecycle regression check

## Production evidence

Vercel recorded 9 model_not_available failures in seven days from the SmartPDFs image endpoint.

## Verification

- pnpm verify:models
- Preview-configured Next.js production build
- replacement ID confirmed as a current Together serverless model

This PR is prepared for review and has not been merged.